### PR TITLE
Index luau files for GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.luau linguist-language=Lua
+*.*.luau linguist-language=Lua


### PR DESCRIPTION
Luau files are not recognized and indexed by GitHub, and hence syntax highlighting is not applied to them either. Including this makes GitHub treat luau like lua so it is indexed in the languages list and syntax highlighting is applied to some extent. Also helps improve code readability in the web view.